### PR TITLE
Ffmpeg encode

### DIFF
--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -4,7 +4,11 @@
         <subMenu id="mplay_batch">
             <label>Batch</label>
             <titleItem><label>Output</label></titleItem>
-            <scriptMenuStripRadio>
+            <scriptToggleItem id="output_video">
+                <label>Export Video</label>
+                <variableName>MPLAY_BATCH_OUTPUT_VIDEO</variableName>
+            </scriptToggleItem>
+            <!-- <scriptMenuStripRadio>
                 <variableName>MPLAY_BATCH_OUTPUT</variableName>
                 <scriptRadioItem id="output_img_seq">
                     <label>Image Sequence</label>
@@ -14,7 +18,7 @@
                     <label>Video</label>
                     <variableValue>video</variableValue>
                 </scriptRadioItem>
-            </scriptMenuStripRadio>
+            </scriptMenuStripRadio> -->
             <scriptToggleItem id="keep_video_source">
                 <label>Keep Image Sequence (Video)</label>
                 <variableName>MPLAY_BATCH_KEEP_VIDEO_SOURCE</variableName>

--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -8,7 +8,8 @@
                 <label>Export Video</label>
                 <variableName>MPLAY_BATCH_OUTPUT_VIDEO</variableName>
                 <!-- MPlay does not seem to reflect global variables changing on toggleItems like the normal MainMenu does, so "Export Video" will remain checked, however, the video output will be skipped. -->
-                <scriptCode><![CDATA[import mplay_batch;hou.hscript('if ($MPLAY_BATCH_OUTPUT_VIDEO) then;set -g MPLAY_BATCH_OUTPUT_VIDEO = 0;else;set -g MPLAY_BATCH_OUTPUT_VIDEO = 1;endif;') if mplay_batch.Environment.find_ffmpeg() else hou.hscript('set -g MPLAY_BATCH_OUTPUT_VIDEO = 0');hou.hscript('varchange MPLAY_BATCH_OUTPUT_VIDEO')]]></scriptCode>
+                <!--It might be confusing if the user tries to uncheck the box and sees the error again...Leave it out til the RFE is fixed-->
+                <!-- <scriptCode><![CDATA[import mplay_batch;hou.hscript('if ($MPLAY_BATCH_OUTPUT_VIDEO) then;set -g MPLAY_BATCH_OUTPUT_VIDEO = 0;else;set -g MPLAY_BATCH_OUTPUT_VIDEO = 1;endif;') if mplay_batch.Environment.find_ffmpeg() else hou.hscript('set -g MPLAY_BATCH_OUTPUT_VIDEO = 0');hou.hscript('varchange MPLAY_BATCH_OUTPUT_VIDEO')]]></scriptCode> -->
             </scriptToggleItem>
             <!-- <scriptMenuStripRadio>
                 <variableName>MPLAY_BATCH_OUTPUT</variableName>

--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -3,16 +3,28 @@
     <menuBar>
         <subMenu id="mplay_batch">
             <label>Batch</label>
-            <titleItem>
-                <label>Save</label>
-            </titleItem>
+            <titleItem><label>Output</label></titleItem>
+            <scriptMenuStripRadio>
+                <variableName>MPLAY_BATCH_OUTPUT</variableName>
+                <scriptRadioItem id="output_img_seq">
+                    <label>Image Sequence</label>
+                    <variableValue>img_seq</variableValue>
+                </scriptRadioItem>
+                <scriptRadioItem id="output_video">
+                    <label>Video</label>
+                    <variableValue>video</variableValue>
+                </scriptRadioItem>
+            </scriptMenuStripRadio>
+            <scriptToggleItem id="keep_video_source">
+                <label>Keep Image Sequence (Video)</label>
+                <variableName>MPLAY_BATCH_KEEP_VIDEO_SOURCE</variableName>
+                <scriptCode><![CDATA[hou.hscript("if ( $MPLAY_BATCH_KEEP_VIDEO_SOURCE ) then;set -g MPLAY_BATCH_KEEP_VIDEO_SOURCE = 0;else;set -g MPLAY_BATCH_KEEP_VIDEO_SOURCE = 1;endif;");hou.hscript("varchange MPLAY_BATCH_KEEP_VIDEO_SOURCE")]]></scriptCode>
+            </scriptToggleItem>
+            <titleItem><label>Save</label></titleItem>
             <scriptItem id="save_current">
                 <label>Save Current Sequence</label>
                 <scriptCode><![CDATA[import mplay_batch;mplay_batch.main(kwargs)]]></scriptCode>
             </scriptItem>
-            <titleItem>
-                <label>Batch Save</label>
-            </titleItem>
             <scriptItem id="save_all_seqs">
                 <label>Save All Sequences</label>
                 <scriptCode><![CDATA[import mplay_batch;mplay_batch.main(kwargs)]]></scriptCode>
@@ -21,9 +33,7 @@
                 <label>Save All Open Viewers</label>
                 <scriptCode><![CDATA[import mplay_batch;mplay_batch.main(kwargs)]]></scriptCode>
 </scriptItem> -->
-            <titleItem>
-                <label>Utilities</label>
-            </titleItem>
+            <titleItem><label>Utilities</label></titleItem>
             <scriptItem id="open_flipbook_dir">
                 <label>Open Flipbook Directory</label>
                 <scriptCode><![CDATA[import mplay_batch;mplay_batch.main(kwargs)]]></scriptCode>

--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -18,7 +18,6 @@
             <scriptToggleItem id="keep_video_source">
                 <label>Keep Image Sequence (Video)</label>
                 <variableName>MPLAY_BATCH_KEEP_VIDEO_SOURCE</variableName>
-                <scriptCode><![CDATA[hou.hscript("if ( $MPLAY_BATCH_KEEP_VIDEO_SOURCE ) then;set -g MPLAY_BATCH_KEEP_VIDEO_SOURCE = 0;else;set -g MPLAY_BATCH_KEEP_VIDEO_SOURCE = 1;endif;");hou.hscript("varchange MPLAY_BATCH_KEEP_VIDEO_SOURCE")]]></scriptCode>
             </scriptToggleItem>
             <titleItem><label>Save</label></titleItem>
             <scriptItem id="save_current">

--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -28,10 +28,6 @@
                 <label>Save All Sequences</label>
                 <scriptCode><![CDATA[import mplay_batch;mplay_batch.main(kwargs)]]></scriptCode>
             </scriptItem>
-            <!-- <scriptItem id="save_all_viewers">
-                <label>Save All Open Viewers</label>
-                <scriptCode><![CDATA[import mplay_batch;mplay_batch.main(kwargs)]]></scriptCode>
-</scriptItem> -->
             <titleItem><label>Utilities</label></titleItem>
             <scriptItem id="open_flipbook_dir">
                 <label>Open Flipbook Directory</label>

--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -7,7 +7,8 @@
             <scriptToggleItem id="output_video">
                 <label>Export Video</label>
                 <variableName>MPLAY_BATCH_OUTPUT_VIDEO</variableName>
-                <scriptCode><![CDATA[import mplay_batch;mplay_batch.Environment.find_ffmpeg();hou.hscript('if ($MPLAY_BATCH_OUTPUT_VIDEO) then;set -g MPLAY_BATCH_OUTPUT_VIDEO = 0;else;set -g MPLAY_BATCH_OUTPUT_VIDEO = 1;endif;');hou.hscript('varchange MPLAY_BATCH_OUTPUT_VIDEO')]]></scriptCode>
+                <!-- MPlay does not seem to reflect global variables changing on toggleItems like the normal MainMenu does, so "Export Video" will remain checked, however, the video output will be skipped. -->
+                <scriptCode><![CDATA[import mplay_batch;hou.hscript('if ($MPLAY_BATCH_OUTPUT_VIDEO) then;set -g MPLAY_BATCH_OUTPUT_VIDEO = 0;else;set -g MPLAY_BATCH_OUTPUT_VIDEO = 1;endif;') if mplay_batch.Environment.find_ffmpeg() else hou.hscript('set -g MPLAY_BATCH_OUTPUT_VIDEO = 0');hou.hscript('varchange MPLAY_BATCH_OUTPUT_VIDEO')]]></scriptCode>
             </scriptToggleItem>
             <!-- <scriptMenuStripRadio>
                 <variableName>MPLAY_BATCH_OUTPUT</variableName>

--- a/houdini18.5/MainMenuMPlay.xml
+++ b/houdini18.5/MainMenuMPlay.xml
@@ -7,6 +7,7 @@
             <scriptToggleItem id="output_video">
                 <label>Export Video</label>
                 <variableName>MPLAY_BATCH_OUTPUT_VIDEO</variableName>
+                <scriptCode><![CDATA[import mplay_batch;mplay_batch.Environment.find_ffmpeg();hou.hscript('if ($MPLAY_BATCH_OUTPUT_VIDEO) then;set -g MPLAY_BATCH_OUTPUT_VIDEO = 0;else;set -g MPLAY_BATCH_OUTPUT_VIDEO = 1;endif;');hou.hscript('varchange MPLAY_BATCH_OUTPUT_VIDEO')]]></scriptCode>
             </scriptToggleItem>
             <!-- <scriptMenuStripRadio>
                 <variableName>MPLAY_BATCH_OUTPUT</variableName>

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -216,6 +216,19 @@ class Environment(object):
             value = 0
         return value
 
+    @staticmethod
+    def find_ffmpeg():
+        """Locate the ffmpeg executable on disk.
+
+        :raises MissingFFmpegError: Can't find ffmpeg
+        :return: Path to ffmpeg executable
+        :rtype: str
+        """
+        ffmpeg_path = find_executable("ffmpeg")
+        if not ffmpeg_path:
+            raise MissingFFmpegError
+        return ffmpeg_path
+
 
 class SequenceDir(object):
     """A place to write sequences into."""
@@ -410,8 +423,7 @@ class SequenceWriter(object):
         self.cmds = {"hscript": [], "ffmpeg": []}
         self.seqs = []
         if self.video:
-            if not find_executable("ffmpeg"):
-                raise MissingFFmpegError
+            self.env.find_ffmpeg()
 
     def execute(self):
         """Run through command queue."""
@@ -531,10 +543,8 @@ def main(kwargs):
 
     # Check video options
     # TODO: Revert back to Radio Button style when RFE is fixed.
-    keep_source = Environment.check_toggle_variable(
-        "MPLAY_BATCH_KEEP_VIDEO_SOURCE")
-    export_video = Environment.check_toggle_variable(
-        "MPLAY_BATCH_OUTPUT_VIDEO")
+    keep_source = env.check_toggle_variable("MPLAY_BATCH_KEEP_VIDEO_SOURCE")
+    export_video = env.check_toggle_variable("MPLAY_BATCH_OUTPUT_VIDEO")
 
     # Handle menu selection
     writer = SequenceWriter(

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -131,7 +131,7 @@ class Environment(object):
     @video_format.setter
     def video_format(self, extension):
         format_ = re.sub(r"(\.?)(\w*\d*\.*)", r"\2", extension)
-        if not self.find_ffmpeg():
+        if not self.find_ffmpeg(silent=True):
             # Just set it anyway and do an early return.
             self._video_format = format_
             return
@@ -215,7 +215,7 @@ class Environment(object):
         return value
 
     @staticmethod
-    def find_ffmpeg():
+    def find_ffmpeg(silent=False):
         """Locate the ffmpeg executable on disk.
 
         :raises MissingFFmpegError: Can't find ffmpeg
@@ -223,7 +223,7 @@ class Environment(object):
         :rtype: str
         """
         ffmpeg_path = find_executable("ffmpeg")
-        if not ffmpeg_path:
+        if not ffmpeg_path and not silent:
             raise MissingFFmpegError
         return ffmpeg_path
 

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -411,10 +411,16 @@ class SequenceWriter(object):
 
     @staticmethod
     def format_ffmpeg_cmd(seq, env):
+        # Fix for windows being windows...
+        pattern_type = "glob"
+        pattern = seq.glob_pattern
+        if "win32" in sys.platform:
+            pattern_type = "sequence"
+            pattern = pattern.replace("[0-9]*", "%d")
         ffmpeg_cmd = (
-            "ffmpeg -nostdin -framerate {0} -pix_fmt yuv420p -pattern_type glob"
-            " -i \"{1}\" \"{2}\" -c:v libx264 -movflags faststart ".format(
-                env.fps, seq.glob_pattern, seq.video_path)
+            "ffmpeg -nostdin -framerate {0} -pix_fmt yuv420p -pattern_type {1}"
+            " -i \"{2}\" \"{3}\" -c:v libx264 -movflags faststart ".format(
+                env.fps, pattern_type, pattern, seq.video_path)
         )
         return shlex.split(ffmpeg_cmd)
 

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -53,8 +53,10 @@ class UnsupportedVideoFormatError(ValueError):
 
     def __init__(self, video_format):
         self.message = (
-            "\"{0}\" is not currently supported by MPlay Batch. "
-            "Supported formats include:\n{1}".format(
+            "The \"{0}\" format is not currently supported by MPlay Batch on "
+            "this system.\nSupported formats include:\n{1}\n"
+            "Check the value set for MPLAY_BATCH_VIDEO_FORMAT "
+            "in mplay_batch.json".format(
                 video_format,
                 "\n".join(Environment.valid_video_formats)
             )

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -135,7 +135,7 @@ class Environment(object):
     @video_format.setter
     def video_format(self, extension):
         format_ = re.sub(r"(\.?)(\w*\d*\.*)", r"\2", extension)
-        if format_ in self.valid_formats:
+        if format_ in self.valid_video_formats:
             self._video_format = format_
         else:
             raise UnsupportedVideoFormatError(format_)

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -58,7 +58,7 @@ class UnsupportedVideoFormatError(ValueError):
             "Check the value set for MPLAY_BATCH_VIDEO_FORMAT "
             "in mplay_batch.json".format(
                 video_format,
-                "\n".join(Environment.valid_video_formats)
+                "\n\t".join(Environment.valid_video_formats)
             )
         )
         super(UnsupportedVideoFormatError, self).__init__(self.message)

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -473,6 +473,22 @@ def open_flipbook_dir(env):
         os.system("gio open {0}".format(env.flipbook_dir))
 
 
+def check_toggle_variable(var):
+    """Check the state of menu toggle's variable.
+
+    :param var: Variable to check
+    :type var: str
+    :return: Variable value. -1 if any undefined input
+    :rtype: int
+    """
+    value = -1
+    try:
+        value = int(hou.getenv(var))
+    except (ValueError, TypeError):
+        value = 0
+    return value
+
+
 def main(kwargs):
     """Entry point for the MPlay Batch program.
 
@@ -489,16 +505,15 @@ def main(kwargs):
         open_flipbook_dir(env)
         return
 
-    # Check "Keep Source" option
-    try:
-        keep_source = int(hou.getenv("MPLAY_BATCH_KEEP_VIDEO_SOURCE"))
-    except (ValueError, TypeError):
-        keep_source = 0
+    # Check video options
+    # TODO: Revert back to Radio Button style when RFE is fixed.
+    keep_source = check_toggle_variable("MPLAY_BATCH_KEEP_VIDEO_SOURCE")
+    export_video = check_toggle_variable("MPLAY_BATCH_OUTPUT_VIDEO")
 
     # Handle menu selection
     writer = SequenceWriter(
         env,
-        video=hou.getenv("MPLAY_BATCH_OUTPUT") == "video",
+        video=export_video,
         keep_video_source=keep_source
     )
     try:

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -42,8 +42,8 @@ class MissingFFmpegError(EnvironmentError):
 
     def __str__(self):
         return (
-            "Missing ffmpeg executable."
-            "Please make sure it is installed and available "
+            "Missing ffmpeg executable. "
+            "To export video, please make sure it is installed and available "
             "on the system's PATH"
         )
 

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -134,7 +134,7 @@ class Environment(object):
         dir_ = hou.expandString(dir_)
         if not os.path.exists(dir_):
             raise OSError("Flipbook directory {0} does not exist".format(dir_))
-        elif not os.path.isdir(dir_):
+        if not os.path.isdir(dir_):
             raise ValueError("{0} is not a directory".format(dir_))
         self._flipbook_dir = dir_
 

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -54,7 +54,7 @@ class UnsupportedVideoFormatError(ValueError):
     def __init__(self, video_format):
         self.message = (
             "The \"{0}\" format is not currently supported by MPlay Batch on "
-            "this system.\nSupported formats include:\n{1}\n"
+            "this system.\nSupported formats include:\n\t{1}\n"
             "Check the value set for MPLAY_BATCH_VIDEO_FORMAT "
             "in mplay_batch.json".format(
                 video_format,

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -239,7 +239,7 @@ class Environment(object):
         )
         regex = re.compile(r"\s*(\w*)\s+(\w+)\s+(\w*)")
         formats = []
-        for line in out.split("--")[1].split("\r\n"):
+        for line in out.split("--")[1].split("\n"):
             match = regex.match(line)
             if match:
                 formats.append(match.group(2))

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -528,16 +528,6 @@ class SequenceWriter(object):
                     self.format_ffmpeg_cmd(seq, self.env))
         return self
 
-    def save_all_viewers(self):
-        """Save all open viewers to disk."""
-        imgviews = hou.hscript("imgviewls")
-        for i, view in enumerate(imgviews):
-            seq = Sequence(self.location, index=i)
-            self.cmds["ffmpeg"].append(
-                "imgsave -a {0} {1}".format(seq.path, view))
-            self.seqs.append(seq)
-        return self
-
     @staticmethod
     def format_ffmpeg_cmd(seq, env):
         """Format a command for ffmpeg to export video

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -7,9 +7,9 @@ import shlex
 import subprocess
 import sys
 
-import hou
-
 from distutils.spawn import find_executable
+
+import hou
 
 
 class EnvironmentVariableTypeError(TypeError):
@@ -102,11 +102,21 @@ class Environment(object):
 
     @property
     def video_format(self):
+        """Video format to write with ffmpeg.
+
+        :param extension: Video format
+        :type extension: str
+        """
         return self._video_format
 
     @video_format.setter
     def video_format(self, extension):
-        self._video_format = re.sub(r"(\.?)(\w*\d*\.*)", r"\2", extension)
+        valid_formats = ["mp4", "mov"]
+        if "win32" in sys.platform:
+            valid_formats.append("avi")
+        format_ = re.sub(r"(\.?)(\w*\d*\.*)", r"\2", extension)
+        if format_ in valid_formats:
+            self._video_format = format_
 
     @property
     def flipbook_dir(self):
@@ -310,6 +320,11 @@ class Sequence(object):
 
     @property
     def glob_pattern(self):
+        """Path to this sequence with glob pattern for frame number.
+
+        :return: Glob-patterned file name
+        :rtype: str
+        """
         return "{0}/{1}".format(
             self.seq_dir.dirname,
             self._format_basename(frame_symbol=r"[0-9]*")
@@ -317,6 +332,11 @@ class Sequence(object):
 
     @property
     def video_path(self):
+        """Path to the video component of this sequence.
+
+        :return: Path to the video
+        :rtype: str
+        """
         return "{0}/{1}_{2}_{3}.{4}".format(
             self.seq_dir.dirname,
             self.seq_dir.name,
@@ -370,6 +390,11 @@ class SequenceWriter(object):
 
     @staticmethod
     def remove_image_sequence(seq):
+        """Remove an image sequence from disk.
+
+        :param seq: Sequence to remove
+        :type seq: :class:`Sequence`
+        """
         files = glob.glob(seq.glob_pattern)
         for file_ in files:
             try:
@@ -411,6 +436,15 @@ class SequenceWriter(object):
 
     @staticmethod
     def format_ffmpeg_cmd(seq, env):
+        """Format a command for ffmpeg to export video
+
+        :param seq: Sequence to render
+        :type seq: :class:`Sequence`
+        :param env: Current session/env settings
+        :type env: :class:`Environment`
+        :return: Shlex-formatted command list
+        :rtype: list
+        """
         # Fix for windows being windows...
         pattern_type = "glob"
         pattern = seq.glob_pattern

--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -130,6 +130,7 @@ class Environment(object):
 
     @video_format.setter
     def video_format(self, extension):
+        # TODO: Is it lame that ffmpeg is queried whenever this obj is created?
         format_ = re.sub(r"(\.?)(\w*\d*\.*)", r"\2", extension)
         if not self.find_ffmpeg(silent=True):
             # Just set it anyway and do an early return.


### PR DESCRIPTION
Address issue #4 to allow exporting of video files as well as image sequences. Unless specified, the source image sequence is removed from disk after exporting a video.

For more details, see issue #5  and [the GitHub page](https://jamesrobinsonvfx.github.io/mplay_batch/#export-video)

* Must have `ffmpeg` available on the system `PATH`
* Video Format is modifiable via the env/package