### PR TITLE
Remove -hide_banner flag on linux

### DIFF
--- a/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
+++ b/houdini18.5/python2.7libs/mplay_batch/mplay_batch.py
@@ -278,10 +278,10 @@ class Environment(object):
         :return: List of formats
         :rtype: list of str
         """
-        out = subprocess.check_output(
-            shlex.split("ffmpeg -hide_banner -loglevel error -formats"),
-            **self.subprocess_kwargs()
-        )
+        cmd = shlex.split("ffmpeg -hide_banner -loglevel error -formats")
+        if "linux" in sys.platform:
+            cmd.remove("-hide_banner")
+        out = subprocess.check_output(cmd, **self.subprocess_kwargs())
         regex = re.compile(r"\s*(\w*)\s+(\w+)\s+(\w*)")
         formats = []
         for line in out.split("--")[1].split("\n"):
@@ -670,7 +670,11 @@ class SequenceWriter(object):
             "-c:v libx264 -movflags faststart ".format(
                 env.fps, seq.frange[0], seq.ffmpeg_pattern, seq.video_path)
         )
-        return shlex.split(ffmpeg_cmd)
+        cmd = shlex.split(ffmpeg_cmd)
+        # TODO: Not very DRY. If more issues arise, take care of this elsewhere
+        if "linux" in sys.platform:
+            cmd.remove("-hide_banner")
+        return cmd
 
 
 def open_flipbook_dir(env):


### PR DESCRIPTION
The `-hide_banner` flag was causing issues during Linux testing, and is not needed there. 

The current fix is just to remove it from the 2 commands that use it. If more issues arise for more OSes, it would be better to take care of it in a function someplace else. But for now, the easiest fix is to just test `sys.platform` and remove the flag from the command.